### PR TITLE
Add m6g instance family task limits

### DIFF
--- a/doc_source/container-instance-eni.md
+++ b/doc_source/container-instance-eni.md
@@ -178,6 +178,15 @@ The `c5n`, `m5n`, `m5dn`, `r5n`, and `r5dn` instance types are not supported\.
 |  m5d\.4xlarge  | 7 | 60 | 
 |  m5d\.12xlarge  | 7 | 60 | 
 |  m5d\.24xlarge  | 14 | 120 | 
+| m6 instance family |
+|  m6g\.medium  | 1 | 10 |
+|  m6g\.large  | 2 | 10 |
+|  m6g\.xlarge  | 3 | 20 |
+|  m6g\.2xlarge  | 3 | 40 |
+|  m6g\.4xlarge  | 7 | 60 |
+|  m6g\.8xlarge  | 7 | 60 |
+|  m6g\.12xlarge  | 7 | 60 |
+|  m6g\.16xlarge  | 14 | 120 |
 | p3 instance family | 
 |  p3\.2xlarge  | 3 | 40 | 
 |  p3\.8xlarge  | 7 | 60 | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added task ENI limits for the recent [GA release](https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-ec2-m6g-instances-powered-by-aws-graviton2-processors-generally-available/) of the `m6g` instance family.

This assumes the limits are increased by the same amount as other instances with the same original [max of network interfaces](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI).

I've verified this instance family supports ENI trunking by launching that instance family into a cluster and confirming it has the `ecs.capability.task-eni-trunking` attribute associated with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
